### PR TITLE
docs: Move Codespaces documentation to CODESPACES.md

### DIFF
--- a/CODESPACES.md
+++ b/CODESPACES.md
@@ -1,0 +1,90 @@
+# GitHub Codespaces support
+
+**Backstory**
+
+https://github.com/ipa-lab/hackingBuddyGPT/pull/85#issuecomment-2331166997
+
+> Would it be possible to add codespace support to hackingbuddygpt in a way, that only spawns a single container (maybe with the suid/sudo use-case) and starts hackingBuddyGPT against that container? That might be the 'easiest' show-case/use-case for a new user.
+
+**Steps**
+1. Go to https://github.com/ipa-lab/hackingBuddyGPT
+2. Click the "Code" button.
+3. Click the "Codespaces" tab.
+4. Click the "Create codespace on main" button.
+5. Wait for Codespaces to start — This may take upwards of 10 minutes.
+
+> Setting up remote connection: Building codespace...
+
+6. After Codespaces started, you may need to restart a new Terminal via the Command Palette:
+
+Press the key combination:
+
+> `⇧⌘P` `Shift+Command+P` (Mac) / `Ctrl+Shift+P` (Windows/Linux)
+
+In the Command Palette, type `>` and `Terminal: Create New Terminal` and press the return key.
+
+7. You should see a new terminal similar to the following:
+
+> 👋 Welcome to Codespaces! You are on our default image.
+>
+>    `-` It includes runtimes and tools for Python, Node.js, Docker, and more. See the full list here: https://aka.ms/ghcs-default-image
+>
+>    `-` Want to use a custom image instead? Learn more here: https://aka.ms/configure-codespace
+>
+> 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
+>
+> 📝 Edit away, run your app as usual, and we'll automatically make it available for you to access.
+>
+> @github-username ➜ /workspaces/hackingBuddyGPT (main) $
+
+Type the following to manually run:
+```bash
+./scripts/codespaces_start_hackingbuddygpt_against_a_container.sh
+```
+7. Eventually, you should see:
+
+> Currently, May 2024, running hackingBuddyGPT with GPT-4-turbo against a benchmark containing 13 VMs (with maximum 20 tries per VM) cost around $5.
+>
+> Therefore, running hackingBuddyGPT with GPT-4-turbo against containing a container with maximum 10 tries would cost around $0.20.
+>
+> Enter your OpenAI API key and press the return key:
+
+8. As requested, please enter your OpenAI API key and press the return key.
+
+9. hackingBuddyGPT should start:
+
+> Starting hackingBuddyGPT against a container...
+
+10. If your OpenAI API key is *valid*, then you should see output similar to the following:
+
+> [00:00:00] Starting turn 1 of 10
+>
+> Got command from LLM:
+>
+> …
+>
+> [00:01:00] Starting turn 10 of 10
+>
+> …
+>
+> Run finished
+>
+> maximum turn number reached
+
+11. If your OpenAI API key is *invalid*, then you should see output similar to the following:
+
+> [00:00:00] Starting turn 1 of 10
+>
+> Traceback (most recent call last):
+>
+> …
+>
+> Exception: Error from OpenAI Gateway (401
+
+**References**
+* https://docs.github.com/en/codespaces
+* https://docs.github.com/en/codespaces/getting-started/quickstart
+* https://docs.github.com/en/codespaces/reference/using-the-vs-code-command-palette-in-codespaces
+* https://openai.com/api/pricing/
+* https://platform.openai.com/docs/quickstart
+* https://platform.openai.com/api-keys

--- a/README.md
+++ b/README.md
@@ -190,96 +190,15 @@ We are using vulnerable Linux systems running in Virtual Machines for this. Neve
 >
 > We are using virtual machines from our [Linux Privilege-Escalation Benchmark](https://github.com/ipa-lab/benchmark-privesc-linux) project. Feel free to use them for your own research!
 
-## GitHub Codespaces support
+## Use Cases
 
-**Backstory**
+Mac, Docker Desktop and Gemini-OpenAI-Proxy:
 
-https://github.com/ipa-lab/hackingBuddyGPT/pull/85#issuecomment-2331166997
+* See [MAC.md](MAC.md)
 
-> Would it be possible to add codespace support to hackingbuddygpt in a way, that only spawns a single container (maybe with the suid/sudo use-case) and starts hackingBuddyGPT against that container? That might be the 'easiest' show-case/use-case for a new user.
+GitHub Codespaces:
 
-**Steps**
-1. Go to https://github.com/ipa-lab/hackingBuddyGPT
-2. Click the "Code" button.
-3. Click the "Codespaces" tab.
-4. Click the "Create codespace on main" button.
-5. Wait for Codespaces to start — This may take upwards of 10 minutes.
-
-> Setting up remote connection: Building codespace...
-
-6. After Codespaces started, you may need to restart a new Terminal via the Command Palette:
-
-Press the key combination:
-
-> `⇧⌘P` `Shift+Command+P` (Mac) / `Ctrl+Shift+P` (Windows/Linux)
-
-In the Command Palette, type `>` and `Terminal: Create New Terminal` and press the return key.
-
-7. You should see a new terminal similar to the following:
-
-> 👋 Welcome to Codespaces! You are on our default image.
->
->    `-` It includes runtimes and tools for Python, Node.js, Docker, and more. See the full list here: https://aka.ms/ghcs-default-image
->
->    `-` Want to use a custom image instead? Learn more here: https://aka.ms/configure-codespace
->
-> 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
->
-> 📝 Edit away, run your app as usual, and we'll automatically make it available for you to access.
->
-> @github-username ➜ /workspaces/hackingBuddyGPT (main) $
-
-Type the following to manually run:
-```bash
-./scripts/codespaces_start_hackingbuddygpt_against_a_container.sh
-```
-7. Eventually, you should see:
-
-> Currently, May 2024, running hackingBuddyGPT with GPT-4-turbo against a benchmark containing 13 VMs (with maximum 20 tries per VM) cost around $5.
->
-> Therefore, running hackingBuddyGPT with GPT-4-turbo against containing a container with maximum 10 tries would cost around $0.20.
->
-> Enter your OpenAI API key and press the return key:
-
-8. As requested, please enter your OpenAI API key and press the return key.
-
-9. hackingBuddyGPT should start:
-
-> Starting hackingBuddyGPT against a container...
-
-10. If your OpenAI API key is *valid*, then you should see output similar to the following:
-
-> [00:00:00] Starting turn 1 of 10
->
-> Got command from LLM:
->
-> …
->
-> [00:01:00] Starting turn 10 of 10
->
-> …
->
-> Run finished
->
-> maximum turn number reached
-
-11. If your OpenAI API key is *invalid*, then you should see output similar to the following:
-
-> [00:00:00] Starting turn 1 of 10
->
-> Traceback (most recent call last):
->
-> …
->
-> Exception: Error from OpenAI Gateway (401
-
-**References**
-* https://docs.github.com/en/codespaces
-* https://docs.github.com/en/codespaces/getting-started/quickstart
-* https://docs.github.com/en/codespaces/reference/using-the-vs-code-command-palette-in-codespaces
-* https://openai.com/api/pricing/
-* https://platform.openai.com/docs/quickstart
-* https://platform.openai.com/api-keys
+* See [CODESPACES.md](CODESPACES.md)
 
 ## Run the Hacking Agent
 
@@ -299,12 +218,6 @@ $ python src/hackingBuddyGPT/cli/wintermute.py LinuxPrivesc --llm.api_key=sk...C
 # install dependencies for testing if you want to run the tests
 $ pip install '.[testing]'
 ```
-
-## Use Cases
-
-Mac, Docker Desktop and Gemini-OpenAI-Proxy:
-
-* See https://github.com/ipa-lab/hackingBuddyGPT/blob/main/MAC.md
 
 ## Publications about hackingBuddyGPT
 


### PR DESCRIPTION
Related https://github.com/ipa-lab/hackingBuddyGPT/pull/96#issuecomment-2513775069 https://github.com/ipa-lab/hackingBuddyGPT/pull/98 https://github.com/lloydchang/ipa-lab-hackingBuddyGPT/pull/3 https://github.com/lloydchang/ipa-lab-hackingBuddyGPT/pull/4 https://github.com/lloydchang/ipa-lab-hackingBuddyGPT/pull/5 https://github.com/lloydchang/ipa-lab-hackingBuddyGPT/pull/6

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move Codespaces documentation from `README.md` to `CODESPACES.md` and update references.
> 
>   - **Documentation**:
>     - Move Codespaces setup instructions from `README.md` to `CODESPACES.md`.
>     - Update `README.md` to reference `CODESPACES.md` for Codespaces setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lloydchang%2Fipa-lab-hackingBuddyGPT&utm_source=github&utm_medium=referral)<sup> for 9e81f3b2189055553a79d6687d483addef498608. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->